### PR TITLE
higher gas limit for SNX staking

### DIFF
--- a/yam-www/src/hooks/useStake.ts
+++ b/yam-www/src/hooks/useStake.ts
@@ -5,11 +5,11 @@ import { Contract } from "web3-eth-contract"
 
 import { stake } from '../yamUtils'
 
-const useStake = (poolContract: Contract) => {
+const useStake = (poolContract: Contract, tokenName: string) => {
   const { account } = useWallet()
 
   const handleStake = useCallback(async (amount: string) => {
-    const txHash = await stake(poolContract, amount, account)
+    const txHash = await stake(poolContract, amount, account, tokenName)
     console.log(txHash)
   }, [account, poolContract])
 

--- a/yam-www/src/views/Farm/components/Stake.tsx
+++ b/yam-www/src/views/Farm/components/Stake.tsx
@@ -45,7 +45,7 @@ const Stake: React.FC<StakeProps> = ({
   const tokenBalance = useTokenBalance(tokenContract.options.address)
   const stakedBalance = useStakedBalance(poolContract)
 
-  const { onStake } = useStake(poolContract)
+  const { onStake } = useStake(poolContract, tokenName);
   const { onUnstake } = useUnstake(poolContract)
 
   const [onPresentDeposit] = useModal(
@@ -55,7 +55,7 @@ const Stake: React.FC<StakeProps> = ({
       tokenName={tokenName}
     />
   )
-  
+
   const [onPresentWithdraw] = useModal(
     <WithdrawModal
       max={stakedBalance}

--- a/yam-www/src/yamUtils/index.js
+++ b/yam-www/src/yamUtils/index.js
@@ -7,16 +7,22 @@ BigNumber.config({
   DECIMAL_PLACES: 80,
 });
 
+const GAS_LIMIT = {
+  DEFAULT: 200000,
+  SNX: 850000,
+};
+
 export const getPoolStartTime = async (poolContract) => {
   return await poolContract.methods.starttime().call()
 }
 
-export const stake = async (poolContract, amount, account) => {
+export const stake = async (poolContract, amount, account, tokenName) => {
   let now = new Date().getTime() / 1000;
+  const gas = GAS_LIMIT[tokenName.toUpperCase()] || GAS_LIMIT.DEFAULT;
   if (now >= 1597172400) {
     return poolContract.methods
       .stake((new BigNumber(amount).times(new BigNumber(10).pow(18))).toString())
-      .send({ from: account, gas: 200000 })
+      .send({ from: account, gas })
       .on('transactionHash', tx => {
         console.log(tx)
         return tx.transactionHash

--- a/yam-www/src/yamUtils/index.js
+++ b/yam-www/src/yamUtils/index.js
@@ -8,8 +8,10 @@ BigNumber.config({
 });
 
 const GAS_LIMIT = {
-  DEFAULT: 200000,
-  SNX: 850000,
+  STAKING: {
+    DEFAULT: 200000,
+    SNX: 850000,
+  }
 };
 
 export const getPoolStartTime = async (poolContract) => {
@@ -18,7 +20,7 @@ export const getPoolStartTime = async (poolContract) => {
 
 export const stake = async (poolContract, amount, account, tokenName) => {
   let now = new Date().getTime() / 1000;
-  const gas = GAS_LIMIT[tokenName.toUpperCase()] || GAS_LIMIT.DEFAULT;
+  const gas = GAS_LIMIT.STAKING[tokenName.toUpperCase()] || GAS_LIMIT.STAKING.DEFAULT;
   if (now >= 1597172400) {
     return poolContract.methods
       .stake((new BigNumber(amount).times(new BigNumber(10).pow(18))).toString())


### PR DESCRIPTION
I can see you guys are using a default gas limit of 200,000 for staking. This is way too low for SNX and I can see lots of `out of gas` transactions on Etherscan because of that.

I've added a `GAS_LIMIT` object which only contains `DEFAULT` and `SNX` for now, but could be updated in case the same issue is happening with other tokens.