### PR TITLE
change script/clean.py target path to relative path

### DIFF
--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -2,8 +2,8 @@ import json
 from pprint import pprint
 networkId = "1"
 networkId2 = "1001"
-from os import listdir
-from os.path import isfile, join
+from os import listdirfrom os import listdir
+from os.path import isfile, join, dirname, abspath
 mypath = dirname(dirname(abspath(__file__))) + "/build/contracts/"
 onlyfiles = [f for f in listdir(mypath) if isfile(join(mypath, f))]
 onlyfiles

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -4,7 +4,7 @@ networkId = "1"
 networkId2 = "1001"
 from os import listdir
 from os.path import isfile, join
-mypath = "/Users/brockelmore/YAM/build/contracts"
+mypath = dirname(dirname(abspath(__file__))) + "/build/contracts/"
 onlyfiles = [f for f in listdir(mypath) if isfile(join(mypath, f))]
 onlyfiles
 


### PR DESCRIPTION
script/clean.py use absolute path (` "/Users/brockelmore/YAM/build/contracts" `)  to target dir. 
This is a code that does not work for users.

So I changed to relative path (`dirname(dirname(abspath(__file__))) + "/build/contracts/"`)