### PR TITLE
Remove typo in StyledLink style

### DIFF
--- a/yam-www/src/views/Home/Home.tsx
+++ b/yam-www/src/views/Home/Home.tsx
@@ -105,7 +105,7 @@ const StyledSpacer = styled.div`
 `
 
 const StyledLink = styled.a`
-  font-weight: 700l
+  font-weight: 700;
   text-decoration: none;
   color: ${props => props.theme.color.primary.main};
 `


### PR DESCRIPTION
This typo also make styles after `l` not applied as well.