### PR TITLE
Increase readability for tests

### DIFF
--- a/yam-www/src/yam/lib/contracts.js
+++ b/yam-www/src/yam/lib/contracts.js
@@ -191,7 +191,7 @@ export class Contracts {
       }
 
       if (confirmationType === Types.ConfirmationType.Simulate) {
-        let g = txOptions.gas;
+        const g = txOptions.gas;
         return { gasEstimate, g };
       }
     }

--- a/yam-www/src/yam/tests/deployment.test.js
+++ b/yam-www/src/yam/tests/deployment.test.js
@@ -34,8 +34,8 @@ describe("post-deployment", () => {
 
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
-    yam.addAccount(accounts[0]);
     user = accounts[0];
+    yam.addAccount(user);
     snapshotId = await yam.testing.snapshot();
   });
 

--- a/yam-www/src/yam/tests/deployment.test.js
+++ b/yam-www/src/yam/tests/deployment.test.js
@@ -46,56 +46,56 @@ describe("post-deployment", () => {
   describe("supply ownership", () => {
 
     test("owner balance", async () => {
-      let balance = await yam.contracts.yam.methods.balanceOf(user).call();
+      const balance = await yam.contracts.yam.methods.balanceOf(user).call();
       expect(balance).toBe(yam.toBigN(7000000).times(yam.toBigN(10**18)).toString())
     });
 
     test("pool balances", async () => {
-      let ycrv_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.ycrv_pool.options.address).call();
+      const ycrv_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.ycrv_pool.options.address).call();
 
       expect(ycrv_balance).toBe(yam.toBigN(1500000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
-      let yfi_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.yfi_pool.options.address).call();
+      const yfi_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.yfi_pool.options.address).call();
 
       expect(yfi_balance).toBe(yam.toBigN(250000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
-      let ampl_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.ampl_pool.options.address).call();
+      const ampl_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.ampl_pool.options.address).call();
 
       expect(ampl_balance).toBe(yam.toBigN(250000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
-      let eth_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.eth_pool.options.address).call();
+      const eth_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.eth_pool.options.address).call();
 
       expect(eth_balance).toBe(yam.toBigN(250000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
-      let snx_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.snx_pool.options.address).call();
+      const snx_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.snx_pool.options.address).call();
 
       expect(snx_balance).toBe(yam.toBigN(250000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
-      let comp_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.comp_pool.options.address).call();
+      const comp_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.comp_pool.options.address).call();
 
       expect(comp_balance).toBe(yam.toBigN(250000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
-      let lend_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.lend_pool.options.address).call();
+      const lend_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.lend_pool.options.address).call();
 
       expect(lend_balance).toBe(yam.toBigN(250000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
-      let link_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.link_pool.options.address).call();
+      const link_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.link_pool.options.address).call();
 
       expect(link_balance).toBe(yam.toBigN(250000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
-      let mkr_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.mkr_pool.options.address).call();
+      const mkr_balance = await yam.contracts.yam.methods.balanceOf(yam.contracts.mkr_pool.options.address).call();
 
       expect(mkr_balance).toBe(yam.toBigN(250000).times(yam.toBigN(10**18)).times(yam.toBigN(1)).toString())
 
     });
 
     test("total supply", async () => {
-      let ts = await yam.contracts.yam.methods.totalSupply().call();
+      const ts = await yam.contracts.yam.methods.totalSupply().call();
       expect(ts).toBe("10500000000000000000000000")
     });
 
     test("init supply", async () => {
-      let init_s = await yam.contracts.yam.methods.initSupply().call();
+      const init_s = await yam.contracts.yam.methods.initSupply().call();
       expect(init_s).toBe("10500000000000000000000000000000")
     });
   });
@@ -103,54 +103,54 @@ describe("post-deployment", () => {
   describe("contract ownership", () => {
 
     test("yam gov", async () => {
-      let gov = await yam.contracts.yam.methods.gov().call();
+      const gov = await yam.contracts.yam.methods.gov().call();
       expect(gov).toBe(yam.contracts.timelock.options.address)
     });
 
     test("rebaser gov", async () => {
-      let gov = await yam.contracts.rebaser.methods.gov().call();
+      const gov = await yam.contracts.rebaser.methods.gov().call();
       expect(gov).toBe(yam.contracts.timelock.options.address)
     });
 
     test("reserves gov", async () => {
-      let gov = await yam.contracts.reserves.methods.gov().call();
+      const gov = await yam.contracts.reserves.methods.gov().call();
       expect(gov).toBe(yam.contracts.timelock.options.address)
     });
 
     test("timelock admin", async () => {
-      let gov = await yam.contracts.timelock.methods.admin().call();
+      const gov = await yam.contracts.timelock.methods.admin().call();
       expect(gov).toBe(yam.contracts.gov.options.address)
     });
 
     test("gov timelock", async () => {
-      let tl = await yam.contracts.gov.methods.timelock().call();
+      const tl = await yam.contracts.gov.methods.timelock().call();
       expect(tl).toBe(yam.contracts.timelock.options.address)
     });
 
     test("gov guardian", async () => {
-      let grd = await yam.contracts.gov.methods.guardian().call();
+      const grd = await yam.contracts.gov.methods.guardian().call();
       expect(grd).toBe("0x0000000000000000000000000000000000000000")
     });
 
     test("pool owner", async () => {
-      let owner = await yam.contracts.eth_pool.methods.owner().call();
+      const owner = await yam.contracts.eth_pool.methods.owner().call();
       expect(owner).toBe(yam.contracts.timelock.options.address)
     });
 
     test("incentives owner", async () => {
-      let owner = await yam.contracts.ycrv_pool.methods.owner().call();
+      const owner = await yam.contracts.ycrv_pool.methods.owner().call();
       expect(owner).toBe(yam.contracts.timelock.options.address)
     });
 
     test("pool rewarder", async () => {
-      let rewarder = await yam.contracts.eth_pool.methods.rewardDistribution().call();
+      const rewarder = await yam.contracts.eth_pool.methods.rewardDistribution().call();
       expect(rewarder).toBe(yam.contracts.timelock.options.address)
     });
   });
 
   describe("timelock delay initiated", () => {
     test("timelock delay initiated", async () => {
-      let inited = await yam.contracts.timelock.methods.admin_initialized().call();
+      const inited = await yam.contracts.timelock.methods.admin_initialized().call();
       expect(inited).toBe(true);
     })
   })

--- a/yam-www/src/yam/tests/distribution.test.js
+++ b/yam-www/src/yam/tests/distribution.test.js
@@ -650,8 +650,8 @@ describe("Distribution", () => {
 
           await yam.testing.increaseTime(i);
 
-          let r = await yam.contracts.uni_pair.methods.getReserves().call();
-          let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+          let [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+          let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
           console.log("quote pre positive rebase", q);
 
           let b = await yam.contracts.rebaser.methods.rebase().send({
@@ -670,8 +670,8 @@ describe("Distribution", () => {
           // increases reserves
           expect(yam.toBigN(resycrv).toNumber()).toBeGreaterThan(0);
 
-          r = await yam.contracts.uni_pair.methods.getReserves().call();
-          q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+          [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+          q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
           console.log("quote", q);
           // not below peg
           expect(yam.toBigN(q).toNumber()).toBeGreaterThan(yam.toBigN(10**18).toNumber());
@@ -905,8 +905,8 @@ describe("Distribution", () => {
 
           await yam.testing.increaseTime(i);
 
-          let r = await yam.contracts.uni_pair.methods.getReserves().call();
-          let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+          let [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+          let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
           console.log("quote pre positive rebase", q);
 
           let b = await yam.contracts.rebaser.methods.rebase().send({
@@ -923,8 +923,8 @@ describe("Distribution", () => {
           expect(yam.toBigN(bal1).toNumber()).toBeLessThan(yam.toBigN(bal).toNumber());
           expect(yam.toBigN(resycrv).toNumber()).toBe(0);
 
-          r = await yam.contracts.uni_pair.methods.getReserves().call();
-          q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+          [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+          q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
           console.log("quote", q);
           // not below peg
           expect(yam.toBigN(q).toNumber()).toBeLessThan(yam.toBigN(10**18).toNumber());

--- a/yam-www/src/yam/tests/distribution.test.js
+++ b/yam-www/src/yam/tests/distribution.test.js
@@ -43,10 +43,9 @@ describe("Distribution", () => {
   let yfi_account = "0x0eb4add4ba497357546da7f5d12d39587ca24606";
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
-    yam.addAccount(accounts[0]);
-    user = accounts[0];
-    yam.addAccount(accounts[1]);
-    user2 = accounts[1];
+    [user, user2] = accounts;
+    yam.addAccount(user);
+    yam.addAccount(user2);
     snapshotId = await yam.testing.snapshot();
   });
 

--- a/yam-www/src/yam/tests/distribution.test.js
+++ b/yam-www/src/yam/tests/distribution.test.js
@@ -32,15 +32,15 @@ describe("Distribution", () => {
   let snapshotId;
   let user;
   let user2;
-  let ycrv_account = "0x0eb4add4ba497357546da7f5d12d39587ca24606";
-  let weth_account = "0xf9e11762d522ea29dd78178c9baf83b7b093aacc";
-  let uni_ampl_account = "0x8c545be506a335e24145edd6e01d2754296ff018";
-  let comp_account = "0xc89b6f0146642688bb254bf93c28fccf1e182c81";
-  let lend_account = "0x3b08aa814bea604917418a9f0907e7fc430e742c";
-  let link_account = "0xbe6977e08d4479c0a6777539ae0e8fa27be4e9d6";
-  let mkr_account = "0xf37216a8ac034d08b4663108d7532dfcb44583ed";
-  let snx_account = "0xb696d629cd0a00560151a434f6b4478ad6c228d7"
-  let yfi_account = "0x0eb4add4ba497357546da7f5d12d39587ca24606";
+  const ycrv_account = "0x0eb4add4ba497357546da7f5d12d39587ca24606";
+  const weth_account = "0xf9e11762d522ea29dd78178c9baf83b7b093aacc";
+  const uni_ampl_account = "0x8c545be506a335e24145edd6e01d2754296ff018";
+  const comp_account = "0xc89b6f0146642688bb254bf93c28fccf1e182c81";
+  const lend_account = "0x3b08aa814bea604917418a9f0907e7fc430e742c";
+  const link_account = "0xbe6977e08d4479c0a6777539ae0e8fa27be4e9d6";
+  const mkr_account = "0xf37216a8ac034d08b4663108d7532dfcb44583ed";
+  const snx_account = "0xb696d629cd0a00560151a434f6b4478ad6c228d7"
+  const yfi_account = "0x0eb4add4ba497357546da7f5d12d39587ca24606";
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
     [user, user2] = accounts;
@@ -99,7 +99,7 @@ describe("Distribution", () => {
 
     test("cant withdraw more than deposited", async () => {
       await yam.testing.resetEVM("0x2");
-      let latestBlock = await yam.web3.eth.getBlock('latest');
+      const latestBlock = await yam.web3.eth.getBlock('latest');
 
       await yam.contracts.weth.methods.transfer(user, yam.toBigN(2000).times(yam.toBigN(10**18)).toString()).send({
         from: weth_account
@@ -108,9 +108,9 @@ describe("Distribution", () => {
         from: uni_ampl_account
       });
 
-      let starttime = await yam.contracts.eth_pool.methods.starttime().call();
+      const starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-      let waittime = starttime - latestBlock["timestamp"];
+      const waittime = starttime - latestBlock["timestamp"];
       if (waittime > 0) {
         await yam.testing.increaseTime(waittime);
       }
@@ -195,11 +195,11 @@ describe("Distribution", () => {
 
       rpt = await yam.contracts.eth_pool.methods.rewardPerToken().call();
 
-      let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+      const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
       console.log(earned, ysf, rpt);
 
-      let j = await yam.contracts.eth_pool.methods.getReward().send({
+      const j = await yam.contracts.eth_pool.methods.getReward().send({
         from: user,
         gas: 300000
       });
@@ -225,7 +225,7 @@ describe("Distribution", () => {
           gas: 80000
         });
 
-        let ycrv_bal = await yam.contracts.ycrv.methods.balanceOf(user).call()
+        const ycrv_bal = await yam.contracts.ycrv.methods.balanceOf(user).call()
 
         console.log("ycrv_bal bal", ycrv_bal)
 
@@ -244,13 +244,13 @@ describe("Distribution", () => {
           gas: 8000000
         });
 
-        let pair = await yam.contracts.uni_fact.methods.getPair(
+        const pair = await yam.contracts.uni_fact.methods.getPair(
           yam.contracts.yam.options.address,
           yam.contracts.ycrv.options.address
         ).call();
 
         yam.contracts.uni_pair.options.address = pair;
-        let bal = await yam.contracts.uni_pair.methods.balanceOf(user).call();
+        const bal = await yam.contracts.uni_pair.methods.balanceOf(user).call();
 
         await yam.contracts.uni_pair.methods.approve(
           yam.contracts.ycrv_pool.options.address,
@@ -309,11 +309,11 @@ describe("Distribution", () => {
         await yam.contracts.UNIAmpl.methods.transfer(user, "5000000000000000").send({
           from: uni_ampl_account
         });
-        let latestBlock = await yam.web3.eth.getBlock('latest');
+        const latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.eth_pool.methods.starttime().call();
+        const starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -331,7 +331,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.ampl_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.ampl_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.ampl_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.ampl_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -342,14 +342,12 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.ampl_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
-
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
         //console.log(earned, ysf, rpt);
 
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
-
-        let j = await yam.contracts.ampl_pool.methods.exit().send({
+        const j = await yam.contracts.ampl_pool.methods.exit().send({
           from: user,
           gas: 300000
         });
@@ -367,14 +365,12 @@ describe("Distribution", () => {
 
         // expect(weth_bal).toBe(yam.toBigN(2000).times(yam.toBigN(10**18)).toString())
 
-        let ampl_bal = await yam.contracts.UNIAmpl.methods.balanceOf(user).call()
-
+        const ampl_bal = await yam.contracts.UNIAmpl.methods.balanceOf(user).call()
         expect(ampl_bal).toBe("5000000000000000")
 
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
-
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toString()).toBe(two_fity.times(1).toString())
     });
   });
@@ -387,11 +383,11 @@ describe("Distribution", () => {
           from: weth_account
         });
 
-        let latestBlock = await yam.web3.eth.getBlock('latest');
+        const latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.eth_pool.methods.starttime().call();
+        const starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -409,7 +405,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.eth_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.eth_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.eth_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.eth_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -420,28 +416,28 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.eth_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let j = await yam.contracts.eth_pool.methods.exit().send({
+        const j = await yam.contracts.eth_pool.methods.exit().send({
           from: user,
           gas: 300000
         });
 
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.weth.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.weth.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe("2000000000000000000000")
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toString()).toBe(two_fity.times(1).toString())
     });
     test("rewards from pool 1s eth with rebase", async () => {
@@ -457,9 +453,9 @@ describe("Distribution", () => {
 
         let latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.eth_pool.methods.starttime().call();
+        const starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -477,7 +473,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.eth_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.eth_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.eth_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.eth_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -488,7 +484,7 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.eth_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
@@ -500,7 +496,7 @@ describe("Distribution", () => {
           gas: 300000
         });
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
         console.log("yam bal", yam_bal)
         // start rebasing
@@ -521,7 +517,7 @@ describe("Distribution", () => {
             gas: 80000
           });
 
-          let ycrv_bal = await yam.contracts.ycrv.methods.balanceOf(user).call()
+          const ycrv_bal = await yam.contracts.ycrv.methods.balanceOf(user).call()
 
           console.log("ycrv_bal bal", ycrv_bal)
 
@@ -540,7 +536,7 @@ describe("Distribution", () => {
             gas: 8000000
           });
 
-          let pair = await yam.contracts.uni_fact.methods.getPair(
+          const pair = await yam.contracts.uni_fact.methods.getPair(
             yam.contracts.yam.options.address,
             yam.contracts.ycrv.options.address
           ).call();
@@ -604,7 +600,7 @@ describe("Distribution", () => {
           });
 
           // init twap
-          let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+          const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
 
           // wait 12 hours
           await yam.testing.increaseTime(12 * 60 * 60);
@@ -654,16 +650,16 @@ describe("Distribution", () => {
           let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
           console.log("quote pre positive rebase", q);
 
-          let b = await yam.contracts.rebaser.methods.rebase().send({
+          const b = await yam.contracts.rebaser.methods.rebase().send({
             from: user,
             gas: 2500000
           });
 
-          let bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
+          const bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
 
-          let resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
+          const resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
-          let resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
+          const resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
           // new balance > old balance
           expect(yam.toBigN(bal).toNumber()).toBeLessThan(yam.toBigN(bal1).toNumber());
@@ -686,14 +682,14 @@ describe("Distribution", () => {
         });
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.weth.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.weth.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe("2000000000000000000000")
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(
           yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toNumber()
         ).toBeGreaterThan(two_fity.toNumber())
@@ -711,9 +707,9 @@ describe("Distribution", () => {
 
         let latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.eth_pool.methods.starttime().call();
+        const starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -731,7 +727,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.eth_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.eth_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.eth_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.eth_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -742,7 +738,7 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.eth_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
@@ -775,7 +771,7 @@ describe("Distribution", () => {
             gas: 80000
           });
 
-          let ycrv_bal = await yam.contracts.ycrv.methods.balanceOf(user).call()
+          const ycrv_bal = await yam.contracts.ycrv.methods.balanceOf(user).call()
 
           console.log("ycrv_bal bal", ycrv_bal)
 
@@ -795,7 +791,7 @@ describe("Distribution", () => {
             gas: 8000000
           });
 
-          let pair = await yam.contracts.uni_fact.methods.getPair(
+          const pair = await yam.contracts.uni_fact.methods.getPair(
             yam.contracts.yam.options.address,
             yam.contracts.ycrv.options.address
           ).call();
@@ -859,7 +855,7 @@ describe("Distribution", () => {
           });
 
           // init twap
-          let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+          const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
 
           // wait 12 hours
           await yam.testing.increaseTime(12 * 60 * 60);
@@ -909,16 +905,16 @@ describe("Distribution", () => {
           let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
           console.log("quote pre positive rebase", q);
 
-          let b = await yam.contracts.rebaser.methods.rebase().send({
+          const b = await yam.contracts.rebaser.methods.rebase().send({
             from: user,
             gas: 2500000
           });
 
-          let bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
+          const bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
 
-          let resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
+          const resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
-          let resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
+          const resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
           expect(yam.toBigN(bal1).toNumber()).toBeLessThan(yam.toBigN(bal).toNumber());
           expect(yam.toBigN(resycrv).toNumber()).toBe(0);
@@ -939,14 +935,14 @@ describe("Distribution", () => {
         });
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.weth.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.weth.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe("2000000000000000000000")
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(
           yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toNumber()
         ).toBeLessThan(two_fity.toNumber())
@@ -960,11 +956,11 @@ describe("Distribution", () => {
           from: yfi_account
         });
 
-        let latestBlock = await yam.web3.eth.getBlock('latest');
+        const latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.yfi_pool.methods.starttime().call();
+        const starttime = await yam.contracts.yfi_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -982,7 +978,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.yfi_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.yfi_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.yfi_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.yfi_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -993,28 +989,28 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.yfi_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let j = await yam.contracts.yfi_pool.methods.exit().send({
+        const j = await yam.contracts.yfi_pool.methods.exit().send({
           from: user,
           gas: 300000
         });
 
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.yfi.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.yfi.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe("500000000000000000000")
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toString()).toBe(two_fity.times(1).toString())
     });
   });
@@ -1026,11 +1022,11 @@ describe("Distribution", () => {
           from: comp_account
         });
 
-        let latestBlock = await yam.web3.eth.getBlock('latest');
+        const latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.comp_pool.methods.starttime().call();
+        const starttime = await yam.contracts.comp_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1048,7 +1044,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.comp_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.comp_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.comp_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.comp_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -1059,28 +1055,28 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.comp_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let j = await yam.contracts.comp_pool.methods.exit().send({
+        const j = await yam.contracts.comp_pool.methods.exit().send({
           from: user,
           gas: 300000
         });
 
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.comp.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.comp.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe("50000000000000000000000")
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toString()).toBe(two_fity.times(1).toString())
     });
   });
@@ -1094,11 +1090,11 @@ describe("Distribution", () => {
           from: lend_account
         });
 
-        let latestBlock = await yam.web3.eth.getBlock('latest');
+        const latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.lend_pool.methods.starttime().call();
+        const starttime = await yam.contracts.lend_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1116,7 +1112,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.lend_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.lend_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.lend_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.lend_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -1127,28 +1123,28 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.lend_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let j = await yam.contracts.lend_pool.methods.exit().send({
+        const j = await yam.contracts.lend_pool.methods.exit().send({
           from: user,
           gas: 300000
         });
 
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.lend.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.lend.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe("10000000000000000000000000")
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toString()).toBe(two_fity.times(1).toString())
     });
   });
@@ -1163,11 +1159,11 @@ describe("Distribution", () => {
           from: link_account
         });
 
-        let latestBlock = await yam.web3.eth.getBlock('latest');
+        const latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.link_pool.methods.starttime().call();
+        const starttime = await yam.contracts.link_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1185,7 +1181,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.link_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.link_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.link_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.link_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -1196,28 +1192,28 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.link_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let j = await yam.contracts.link_pool.methods.exit().send({
+        const j = await yam.contracts.link_pool.methods.exit().send({
           from: user,
           gas: 300000
         });
 
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.link.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.link.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe("10000000000000000000000000")
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toString()).toBe(two_fity.times(1).toString())
     });
   });
@@ -1226,17 +1222,17 @@ describe("Distribution", () => {
     test("rewards from pool 1s mkr", async () => {
         await yam.testing.resetEVM("0x2");
         await yam.web3.eth.sendTransaction({from: user2, to: mkr_account, value : yam.toBigN(100000*10**18).toString()});
-        let eth_bal = await yam.web3.eth.getBalance(mkr_account);
+        const eth_bal = await yam.web3.eth.getBalance(mkr_account);
 
         await yam.contracts.mkr.methods.transfer(user, "10000000000000000000000").send({
           from: mkr_account
         });
 
-        let latestBlock = await yam.web3.eth.getBlock('latest');
+        const latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.mkr_pool.methods.starttime().call();
+        const starttime = await yam.contracts.mkr_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1254,7 +1250,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.mkr_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.mkr_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.mkr_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.mkr_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -1265,28 +1261,28 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.mkr_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let j = await yam.contracts.mkr_pool.methods.exit().send({
+        const j = await yam.contracts.mkr_pool.methods.exit().send({
           from: user,
           gas: 300000
         });
 
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.mkr.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.mkr.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe("10000000000000000000000")
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toString()).toBe(two_fity.times(1).toString())
     });
   });
@@ -1309,11 +1305,11 @@ describe("Distribution", () => {
 
         console.log(snx_bal)
 
-        let latestBlock = await yam.web3.eth.getBlock('latest');
+        const latestBlock = await yam.web3.eth.getBlock('latest');
 
-        let starttime = await yam.contracts.snx_pool.methods.starttime().call();
+        const starttime = await yam.contracts.snx_pool.methods.starttime().call();
 
-        let waittime = starttime - latestBlock["timestamp"];
+        const waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1331,7 +1327,7 @@ describe("Distribution", () => {
 
         let earned = await yam.contracts.snx_pool.methods.earned(user).call();
 
-        let rr = await yam.contracts.snx_pool.methods.rewardRate().call();
+        const rr = await yam.contracts.snx_pool.methods.rewardRate().call();
 
         let rpt = await yam.contracts.snx_pool.methods.rewardPerToken().call();
         //console.log(earned, rr, rpt);
@@ -1342,28 +1338,28 @@ describe("Distribution", () => {
 
         rpt = await yam.contracts.snx_pool.methods.rewardPerToken().call();
 
-        let ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
+        const ysf = await yam.contracts.yam.methods.yamsScalingFactor().call();
 
         //console.log(earned, ysf, rpt);
 
 
-        let yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let j = await yam.contracts.snx_pool.methods.exit().send({
+        const j = await yam.contracts.snx_pool.methods.exit().send({
           from: user,
           gas: 300000
         });
 
         //console.log(j.events)
 
-        let weth_bal = await yam.contracts.snx.methods.balanceOf(user).call()
+        const weth_bal = await yam.contracts.snx.methods.balanceOf(user).call()
 
         expect(weth_bal).toBe(snx_bal)
 
 
-        let yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
+        const yam_bal2 = await yam.contracts.yam.methods.balanceOf(user).call()
 
-        let two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
+        const two_fity = yam.toBigN(250).times(yam.toBigN(10**3)).times(yam.toBigN(10**18))
         expect(yam.toBigN(yam_bal2).minus(yam.toBigN(yam_bal)).toString()).toBe(two_fity.times(1).toString())
     });
   });

--- a/yam-www/src/yam/tests/distribution.test.js
+++ b/yam-www/src/yam/tests/distribution.test.js
@@ -56,11 +56,11 @@ describe("Distribution", () => {
   describe("pool failures", () => {
     test("cant join pool 1s early", async () => {
       await yam.testing.resetEVM("0x2");
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       let starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-      expect(yam.toBigN(a["timestamp"]).toNumber()).toBeLessThan(yam.toBigN(starttime).toNumber());
+      expect(yam.toBigN(latestBlock["timestamp"]).toNumber()).toBeLessThan(yam.toBigN(starttime).toNumber());
 
       //console.log("starttime", a["timestamp"], starttime);
       await yam.contracts.weth.methods.approve(yam.contracts.eth_pool.options.address, -1).send({from: user});
@@ -75,11 +75,11 @@ describe("Distribution", () => {
       , "not start");
 
 
-      a = await yam.web3.eth.getBlock('latest');
+      latestBlock = await yam.web3.eth.getBlock('latest');
 
       starttime = await yam.contracts.ampl_pool.methods.starttime().call();
 
-      expect(yam.toBigN(a["timestamp"]).toNumber()).toBeLessThan(yam.toBigN(starttime).toNumber());
+      expect(yam.toBigN(latestBlock["timestamp"]).toNumber()).toBeLessThan(yam.toBigN(starttime).toNumber());
 
       //console.log("starttime", a["timestamp"], starttime);
 
@@ -99,7 +99,7 @@ describe("Distribution", () => {
 
     test("cant withdraw more than deposited", async () => {
       await yam.testing.resetEVM("0x2");
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       await yam.contracts.weth.methods.transfer(user, yam.toBigN(2000).times(yam.toBigN(10**18)).toString()).send({
         from: weth_account
@@ -110,7 +110,7 @@ describe("Distribution", () => {
 
       let starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-      let waittime = starttime - a["timestamp"];
+      let waittime = starttime - latestBlock["timestamp"];
       if (waittime > 0) {
         await yam.testing.increaseTime(waittime);
       }
@@ -162,11 +162,11 @@ describe("Distribution", () => {
         from: weth_account
       });
 
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       let starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-      let waittime = starttime - a["timestamp"];
+      let waittime = starttime - latestBlock["timestamp"];
       if (waittime > 0) {
         await yam.testing.increaseTime(waittime);
       } else {
@@ -262,9 +262,9 @@ describe("Distribution", () => {
 
         starttime = await yam.contracts.ycrv_pool.methods.starttime().call();
 
-        a = await yam.web3.eth.getBlock('latest');
+        latestBlock = await yam.web3.eth.getBlock('latest');
 
-        waittime = starttime - a["timestamp"];
+        waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -309,11 +309,11 @@ describe("Distribution", () => {
         await yam.contracts.UNIAmpl.methods.transfer(user, "5000000000000000").send({
           from: uni_ampl_account
         });
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -387,11 +387,11 @@ describe("Distribution", () => {
           from: weth_account
         });
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -455,11 +455,11 @@ describe("Distribution", () => {
           from: weth_account
         });
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -634,7 +634,7 @@ describe("Distribution", () => {
 
           bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-          a = await yam.web3.eth.getBlock('latest');
+          latestBlock = await yam.web3.eth.getBlock('latest');
 
           let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
           offset = yam.toBigN(offset).toNumber();
@@ -642,10 +642,10 @@ describe("Distribution", () => {
           interval = yam.toBigN(interval).toNumber();
 
           let i;
-          if (a["timestamp"] % interval > offset) {
-            i = (interval - (a["timestamp"] % interval)) + offset;
+          if (latestBlock["timestamp"] % interval > offset) {
+            i = (interval - (latestBlock["timestamp"] % interval)) + offset;
           } else {
-            i = offset - (a["timestamp"] % interval);
+            i = offset - (latestBlock["timestamp"] % interval);
           }
 
           await yam.testing.increaseTime(i);
@@ -709,11 +709,11 @@ describe("Distribution", () => {
           from: weth_account
         });
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.eth_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -889,7 +889,7 @@ describe("Distribution", () => {
 
           bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-          a = await yam.web3.eth.getBlock('latest');
+          latestBlock = await yam.web3.eth.getBlock('latest');
 
           let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
           offset = yam.toBigN(offset).toNumber();
@@ -897,10 +897,10 @@ describe("Distribution", () => {
           interval = yam.toBigN(interval).toNumber();
 
           let i;
-          if (a["timestamp"] % interval > offset) {
-            i = (interval - (a["timestamp"] % interval)) + offset;
+          if (latestBlock["timestamp"] % interval > offset) {
+            i = (interval - (latestBlock["timestamp"] % interval)) + offset;
           } else {
-            i = offset - (a["timestamp"] % interval);
+            i = offset - (latestBlock["timestamp"] % interval);
           }
 
           await yam.testing.increaseTime(i);
@@ -960,11 +960,11 @@ describe("Distribution", () => {
           from: yfi_account
         });
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.yfi_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1026,11 +1026,11 @@ describe("Distribution", () => {
           from: comp_account
         });
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.comp_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1094,11 +1094,11 @@ describe("Distribution", () => {
           from: lend_account
         });
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.lend_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1163,11 +1163,11 @@ describe("Distribution", () => {
           from: link_account
         });
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.link_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1232,11 +1232,11 @@ describe("Distribution", () => {
           from: mkr_account
         });
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.mkr_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {
@@ -1309,11 +1309,11 @@ describe("Distribution", () => {
 
         console.log(snx_bal)
 
-        let a = await yam.web3.eth.getBlock('latest');
+        let latestBlock = await yam.web3.eth.getBlock('latest');
 
         let starttime = await yam.contracts.snx_pool.methods.starttime().call();
 
-        let waittime = starttime - a["timestamp"];
+        let waittime = starttime - latestBlock["timestamp"];
         if (waittime > 0) {
           await yam.testing.increaseTime(waittime);
         } else {

--- a/yam-www/src/yam/tests/governance.test.js
+++ b/yam-www/src/yam/tests/governance.test.js
@@ -46,14 +46,10 @@ describe('YAM governance', () => {
   let guy;
   let address = "0x4BC6657283f8f24e27EAc1D21D1deE566C534A9A";
 
-
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
-    yam.addAccount(accounts[0]);
-    user = accounts[0];
-    a1 = accounts[1];
-    a2 = accounts[2];
-    guy = accounts[3];
+    [user, a1, a2, guy] = accounts;
+    yam.addAccount(user);
     snapshotId = await yam.testing.snapshot();
   });
 

--- a/yam-www/src/yam/tests/governance.test.js
+++ b/yam-www/src/yam/tests/governance.test.js
@@ -37,14 +37,14 @@ const oneEther = 10 ** 18;
 const EIP712 = require('./EIP712.js');
 
 describe('YAM governance', () => {
-  let name = "YAM";
-  let chainId = 1001;
+  const name = "YAM";
+  const chainId = 1001;
   let snapshotId;
   let user;
   let a1;
   let a2;
   let guy;
-  let address = "0x4BC6657283f8f24e27EAc1D21D1deE566C534A9A";
+  const address = "0x4BC6657283f8f24e27EAc1D21D1deE566C534A9A";
 
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
@@ -98,7 +98,7 @@ describe('YAM governance', () => {
            },
        };
 
-      let sigHash = EIP712.encodeTypedData(typedData)
+      const sigHash = EIP712.encodeTypedData(typedData)
      const sig = ethUtil.ecsign(ethUtil.toBuffer(sigHash, 'hex'), ethUtil.toBuffer(pvk_a1, 'hex'));
 
 
@@ -137,7 +137,7 @@ describe('YAM governance', () => {
            },
        };
 
-      let sigHash = EIP712.encodeTypedData(typedData)
+      const sigHash = EIP712.encodeTypedData(typedData)
       const sig = ethUtil.ecsign(ethUtil.toBuffer(sigHash, 'hex'), ethUtil.toBuffer(pvk_a1, 'hex'));
 
 
@@ -172,22 +172,22 @@ describe('YAM governance', () => {
            },
        };
 
-      let sigHash = EIP712.encodeTypedData(typedData)
+      const sigHash = EIP712.encodeTypedData(typedData)
       const sig = ethUtil.ecsign(ethUtil.toBuffer(sigHash, 'hex'), ethUtil.toBuffer(pvk_a1, 'hex'));
 
-      let tx = await yam.contracts.yam.methods.delegateBySig(user, 0, 10e9, sig.v, sig.r, sig.s).send({from: a1, gas: 500000});
+      const tx = await yam.contracts.yam.methods.delegateBySig(user, 0, 10e9, sig.v, sig.r, sig.s).send({from: a1, gas: 500000});
       expect(tx.gasUsed < 80000);
-      let k = await yam.contracts.yam.methods.delegates(a1).call();
-      let j = await yam.contracts.yam.methods.delegates(user).call();
+      const k = await yam.contracts.yam.methods.delegates(a1).call();
+      const j = await yam.contracts.yam.methods.delegates(user).call();
       expect(k).toBe(user);
     });
 
     test('delegate', async () => {
-      let d = await yam.contracts.yam.methods.delegates(a1).call()
+      const d = await yam.contracts.yam.methods.delegates(a1).call()
       expect(d).toBe("0x0000000000000000000000000000000000000000");
-      let tx = await yam.contracts.yam.methods.delegate(user).send({from: a1});;
+      const tx = await yam.contracts.yam.methods.delegate(user).send({from: a1});;
       expect(tx.gasUsed < 80000);
-      let k = await yam.contracts.yam.methods.delegates(a1).call();
+      const k = await yam.contracts.yam.methods.delegates(a1).call();
       expect(k).toBe(user);
     });
   });
@@ -195,7 +195,7 @@ describe('YAM governance', () => {
   describe('numCheckpoints', () => {
     it('returns the number of checkpoints for a delegate', async () => {
 
-      let one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
+      const one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
       await yam.contracts.yam.methods.transfer(guy, one_hundred.toString()).send({from: user});
       let nc = await yam.contracts.yam.methods.numCheckpoints(a1).call();
       expect(nc).toBe('0');
@@ -236,7 +236,7 @@ describe('YAM governance', () => {
       // For this test to pass, you must enable blocktimes. it will fail otherwise
 
 
-      let one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
+      const one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
       await yam.contracts.yam.methods.transfer(guy, one_hundred.toString()).send({from: user});
       let nc = await yam.contracts.yam.methods.numCheckpoints(a1).call();
       expect(nc).toBe('0');
@@ -269,7 +269,7 @@ describe('YAM governance', () => {
       cs = await yam.contracts.yam.methods.checkpoints(a1, 2).call();
       expect(cs.votes).toBe("0"); // 0
 
-      let t4 = await yam.contracts.yam.methods.transfer(guy, yam.toBigN(100).times(yam.toBigN(10**18)).times(.2).toString()).send({from: user});
+      const t4 = await yam.contracts.yam.methods.transfer(guy, yam.toBigN(100).times(yam.toBigN(10**18)).times(.2).toString()).send({from: user});
 
       nc = await yam.contracts.yam.methods.numCheckpoints(a1).call();
       expect(nc).toBe('2');
@@ -290,12 +290,12 @@ describe('YAM governance', () => {
     });
 
     test('returns 0 if there are no checkpoints', async () => {
-      let pv = await yam.contracts.yam.methods.getPriorVotes(a1, 0).call();
+      const pv = await yam.contracts.yam.methods.getPriorVotes(a1, 0).call();
       expect(pv).toBe('0');
     });
 
     test('returns the latest block if >= last checkpoint block', async () => {
-      let t1 = await yam.contracts.yam.methods.delegate(a1).send({from: user});
+      const t1 = await yam.contracts.yam.methods.delegate(a1).send({from: user});
       await yam.testing.mineBlock();
       await yam.testing.mineBlock();
 
@@ -308,7 +308,7 @@ describe('YAM governance', () => {
 
     test('returns zero if < first checkpoint block', async () => {
       await yam.testing.mineBlock();
-      let t1 = await yam.contracts.yam.methods.delegate(a1).send({from: user});
+      const t1 = await yam.contracts.yam.methods.delegate(a1).send({from: user});
       await yam.testing.mineBlock();
       await yam.testing.mineBlock();
 
@@ -320,19 +320,19 @@ describe('YAM governance', () => {
     });
 
     it('generally returns the voting balance at the appropriate checkpoint', async () => {
-      let one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
+      const one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
       await yam.contracts.yam.methods.transfer(guy, one_hundred.toString()).send({from: user});
 
-      let t1 = await yam.contracts.yam.methods.delegate(a1).send({from: guy});
+      const t1 = await yam.contracts.yam.methods.delegate(a1).send({from: guy});
       await yam.testing.mineBlock();
       await yam.testing.mineBlock();
-      let t2 = await yam.contracts.yam.methods.transfer(a2, yam.toBigN(100).times(yam.toBigN(10**18)).times(.1).toString()).send({from: guy});
+      const t2 = await yam.contracts.yam.methods.transfer(a2, yam.toBigN(100).times(yam.toBigN(10**18)).times(.1).toString()).send({from: guy});
       await yam.testing.mineBlock();
       await yam.testing.mineBlock();
-      let t3 = await yam.contracts.yam.methods.transfer(a2, yam.toBigN(100).times(yam.toBigN(10**18)).times(.1).toString()).send({from: guy});
+      const t3 = await yam.contracts.yam.methods.transfer(a2, yam.toBigN(100).times(yam.toBigN(10**18)).times(.1).toString()).send({from: guy});
       await yam.testing.mineBlock();
       await yam.testing.mineBlock();
-      let t4 = await yam.contracts.yam.methods.transfer(guy, yam.toBigN(100).times(yam.toBigN(10**18)).times(.2).toString()).send({from: a2});
+      const t4 = await yam.contracts.yam.methods.transfer(guy, yam.toBigN(100).times(yam.toBigN(10**18)).times(.2).toString()).send({from: a2});
       await yam.testing.mineBlock();
       await yam.testing.mineBlock();
 

--- a/yam-www/src/yam/tests/governorAlpha.test.js
+++ b/yam-www/src/yam/tests/governorAlpha.test.js
@@ -59,13 +59,8 @@ describe("governorAlpha#castVote/2", () => {
   beforeAll(async () => {
     await yam.testing.resetEVM("0x2");
     accounts = await yam.web3.eth.getAccounts();
-    yam.addAccount(accounts[0]);
-    user = accounts[0];
-    a1 = accounts[1];
-    a2 = accounts[2];
-    guy = accounts[3];
-    a3 = accounts[4];
-    a4 = accounts[5];
+    [user, a1, a2, guy, a3, a4] = accounts;
+    yam.addAccount(user);
     let one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
     // await yam.contracts.yam.methods.transfer(guy, one_hundred.toString()).send({from: user});
 

--- a/yam-www/src/yam/tests/governorAlpha.test.js
+++ b/yam-www/src/yam/tests/governorAlpha.test.js
@@ -37,8 +37,8 @@ const oneEther = 10 ** 18;
 const EIP712 = require('./EIP712');
 
 describe("governorAlpha#castVote/2", () => {
-  let name = "YAM";
-  let chainId = 1001;
+  const name = "YAM";
+  const chainId = 1001;
   let snapshotId;
   let user;
   let a1;
@@ -46,7 +46,7 @@ describe("governorAlpha#castVote/2", () => {
   let a3;
   let a4;
   let guy;
-  let address = "0x4BC6657283f8f24e27EAc1D21D1deE566C534A9A";
+  const address = "0x4BC6657283f8f24e27EAc1D21D1deE566C534A9A";
   let targets, values, signatures, callDatas, proposalId;
   let accounts;
   // we publish the mnemonic. its is a well known test mnemonic so these pvks
@@ -61,7 +61,7 @@ describe("governorAlpha#castVote/2", () => {
     accounts = await yam.web3.eth.getAccounts();
     [user, a1, a2, guy, a3, a4] = accounts;
     yam.addAccount(user);
-    let one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
+    const one_hundred = yam.toBigN(100).times(yam.toBigN(10**18));
     // await yam.contracts.yam.methods.transfer(guy, one_hundred.toString()).send({from: user});
 
     snapshotId = await yam.testing.snapshot();
@@ -124,11 +124,11 @@ describe("governorAlpha#castVote/2", () => {
 
         proposalId = await yam.contracts.gov.methods.latestProposalIds(actor).call();
 
-        let beforeFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).forVotes;
+        const beforeFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).forVotes;
         await yam.testing.mineBlock();
         await yam.contracts.gov.methods.castVote(proposalId, true).send({ from: actor });
 
-        let afterFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).forVotes;
+        const afterFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).forVotes;
         expect(yam.toBigN(afterFors).toString()).toBe(yam.toBigN(beforeFors).plus(yam.toBigN(400001).times(10**24)).toString());
       })
 
@@ -142,11 +142,11 @@ describe("governorAlpha#castVote/2", () => {
 
         proposalId = await yam.contracts.gov.methods.latestProposalIds(actor).call();
 
-        let beforeFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).againstVotes;
+        const beforeFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).againstVotes;
         await yam.testing.mineBlock();
         await yam.contracts.gov.methods.castVote(proposalId, false).send({ from: actor });
 
-        let afterFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).againstVotes;
+        const afterFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).againstVotes;
         expect(yam.toBigN(afterFors).toString()).toBe(yam.toBigN(beforeFors).plus(yam.toBigN(400001).times(10**24)).toString());
       });
     });
@@ -178,7 +178,7 @@ describe("governorAlpha#castVote/2", () => {
              },
          };
 
-        let sigHash = EIP712.encodeTypedData(typedData)
+        const sigHash = EIP712.encodeTypedData(typedData)
         const sig = ethUtil.ecsign(ethUtil.toBuffer(sigHash, 'hex'), ethUtil.toBuffer(pvk_a1, 'hex'));
 
         await yam.testing.expectThrow(
@@ -218,16 +218,16 @@ describe("governorAlpha#castVote/2", () => {
              },
          };
 
-        let sigHash = EIP712.encodeTypedData(typedData)
+        const sigHash = EIP712.encodeTypedData(typedData)
         const sig = ethUtil.ecsign(ethUtil.toBuffer(sigHash, 'hex'), ethUtil.toBuffer(pvk_a4, 'hex'));
 
-        let beforeFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).forVotes;
+        const beforeFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).forVotes;
         await yam.testing.mineBlock();
         const tx = await yam.contracts.gov.methods.castVoteBySig(proposalId, true, sig.v, sig.r, sig.s).send({from: a4, gas: 100000});
         console.log(tx.events)
         expect(tx.gasUsed < 80000);
 
-        let afterFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).forVotes;
+        const afterFors = (await yam.contracts.gov.methods.proposals(proposalId).call()).forVotes;
         expect(yam.toBigN(afterFors).toString()).toBe(yam.toBigN(beforeFors).plus(yam.toBigN(400001).times(10**24)).toString());
       });
     });

--- a/yam-www/src/yam/tests/migrate.test.js
+++ b/yam-www/src/yam/tests/migrate.test.js
@@ -30,7 +30,7 @@ const oneEther = 10 ** 18;
 
 describe("token_tests", () => {
   let snapshotId;
-  let user = "0x683A78bA1f6b25E29fbBC9Cd1BFA29A51520De84";
+  const user = "0x683A78bA1f6b25E29fbBC9Cd1BFA29A51520De84";
   let new_user;
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
@@ -89,41 +89,41 @@ describe("token_tests", () => {
 
   describe("non-failing", () => {
     test("zeros balance", async () => {
-      let startTime = await yam.contracts.yamV2migration.methods.startTime().call();
-      let timeNow = yam.toBigN((await yam.web3.eth.getBlock('latest'))["timestamp"]);
-      let waitTime = yam.toBigN(startTime).minus(timeNow);
+      const startTime = await yam.contracts.yamV2migration.methods.startTime().call();
+      const timeNow = yam.toBigN((await yam.web3.eth.getBlock('latest'))["timestamp"]);
+      const waitTime = yam.toBigN(startTime).minus(timeNow);
       if (waitTime.toNumber() > 0) {
         await yam.testing.increaseTime(waitTime.toNumber());
       }
       await yam.contracts.yam.methods.approve(yam.contracts.yamV2migration.options.address, "10000000000000000000000000000000000").send({from: user, gas: 1000000});
       await yam.contracts.yamV2migration.methods.migrate().send({from: user, gas: 1000000});
-      let yam_bal = yam.toBigN(await yam.contracts.yam.methods.balanceOf(user).call()).toNumber();
+      const yam_bal = yam.toBigN(await yam.contracts.yam.methods.balanceOf(user).call()).toNumber();
       expect(yam_bal).toBe(0);
     });
     test("v2 balance equal to v1 underlying balance", async () => {
-      let startTime = await yam.contracts.yamV2migration.methods.startTime().call();
-      let timeNow = yam.toBigN((await yam.web3.eth.getBlock('latest'))["timestamp"]);
-      let waitTime = yam.toBigN(startTime).minus(timeNow);
+      const startTime = await yam.contracts.yamV2migration.methods.startTime().call();
+      const timeNow = yam.toBigN((await yam.web3.eth.getBlock('latest'))["timestamp"]);
+      const waitTime = yam.toBigN(startTime).minus(timeNow);
       if (waitTime.toNumber() > 0) {
         await yam.testing.increaseTime(waitTime.toNumber());
       }
-      let yam_bal = yam.toBigN(await yam.contracts.yam.methods.balanceOfUnderlying(user).call());
+      const yam_bal = yam.toBigN(await yam.contracts.yam.methods.balanceOfUnderlying(user).call());
       await yam.contracts.yam.methods.approve(yam.contracts.yamV2migration.options.address, "10000000000000000000000000000000000").send({from: user, gas: 1000000});
       await yam.contracts.yamV2migration.methods.migrate().send({from: user, gas: 1000000});
-      let yamV2_bal = yam.toBigN(await yam.contracts.yamV2.methods.balanceOf(user).call());
+      const yamV2_bal = yam.toBigN(await yam.contracts.yamV2.methods.balanceOf(user).call());
       expect(yam_bal.toString()).toBe(yamV2_bal.toString());
     });
     test("totalSupply increase equal to yam_underlying_bal", async () => {
-      let startTime = await yam.contracts.yamV2migration.methods.startTime().call();
-      let timeNow = yam.toBigN((await yam.web3.eth.getBlock('latest'))["timestamp"]);
-      let waitTime = yam.toBigN(startTime).minus(timeNow);
+      const startTime = await yam.contracts.yamV2migration.methods.startTime().call();
+      const timeNow = yam.toBigN((await yam.web3.eth.getBlock('latest'))["timestamp"]);
+      const waitTime = yam.toBigN(startTime).minus(timeNow);
       if (waitTime.toNumber() > 0) {
         await yam.testing.increaseTime(waitTime.toNumber());
       }
-      let yam_underlying_bal = yam.toBigN(await yam.contracts.yam.methods.balanceOfUnderlying(user).call());
+      const yam_underlying_bal = yam.toBigN(await yam.contracts.yam.methods.balanceOfUnderlying(user).call());
       await yam.contracts.yam.methods.approve(yam.contracts.yamV2migration.options.address, "10000000000000000000000000000000000").send({from: user, gas: 1000000});
       await yam.contracts.yamV2migration.methods.migrate().send({from: user, gas: 1000000});
-      let yamV2_ts = yam.toBigN(await yam.contracts.yamV2.methods.totalSupply().call());
+      const yamV2_ts = yam.toBigN(await yam.contracts.yamV2.methods.totalSupply().call());
       expect(yamV2_ts.toString()).toBe(yam_underlying_bal.toString());
     });
   });

--- a/yam-www/src/yam/tests/rebase.test.js
+++ b/yam-www/src/yam/tests/rebase.test.js
@@ -44,7 +44,7 @@ describe("rebase_tests", () => {
 
   beforeEach(async () => {
     await yam.testing.resetEVM("0x2");
-    let a = await yam.contracts.ycrv.methods.transfer(user, "2000000000000000000000000").send({
+    let latestBlock = await yam.contracts.ycrv.methods.transfer(user, "2000000000000000000000000").send({
       from: unlocked_account
     });
   });
@@ -363,7 +363,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -371,10 +371,10 @@ describe("rebase_tests", () => {
       interval = yam.toBigN(interval).toNumber();
 
       let i;
-      if (a["timestamp"] % interval > offset) {
-        i = (interval - (a["timestamp"] % interval)) + offset;
+      if (latestBlock["timestamp"] % interval > offset) {
+        i = (interval - (latestBlock["timestamp"] % interval)) + offset;
       } else {
-        i = offset - (a["timestamp"] % interval);
+        i = offset - (latestBlock["timestamp"] % interval);
       }
 
       await yam.testing.increaseTime(i);
@@ -533,7 +533,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -541,10 +541,10 @@ describe("rebase_tests", () => {
       interval = yam.toBigN(interval).toNumber();
 
       let i;
-      if (a["timestamp"] % interval > offset) {
-        i = (interval - (a["timestamp"] % interval)) + offset;
+      if (latestBlock["timestamp"] % interval > offset) {
+        i = (interval - (latestBlock["timestamp"] % interval)) + offset;
       } else {
-        i = offset - (a["timestamp"] % interval);
+        i = offset - (latestBlock["timestamp"] % interval);
       }
 
       await yam.testing.increaseTime(i);
@@ -721,7 +721,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -729,10 +729,10 @@ describe("rebase_tests", () => {
       interval = yam.toBigN(interval).toNumber();
 
       let i;
-      if (a["timestamp"] % interval > offset) {
-        i = (interval - (a["timestamp"] % interval)) + offset;
+      if (latestBlock["timestamp"] % interval > offset) {
+        i = (interval - (latestBlock["timestamp"] % interval)) + offset;
       } else {
-        i = offset - (a["timestamp"] % interval);
+        i = offset - (latestBlock["timestamp"] % interval);
       }
 
       await yam.testing.increaseTime(i);
@@ -884,7 +884,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -892,10 +892,10 @@ describe("rebase_tests", () => {
       interval = yam.toBigN(interval).toNumber();
 
       let i;
-      if (a["timestamp"] % interval > offset) {
-        i = (interval - (a["timestamp"] % interval)) + offset;
+      if (latestBlock["timestamp"] % interval > offset) {
+        i = (interval - (latestBlock["timestamp"] % interval)) + offset;
       } else {
-        i = offset - (a["timestamp"] % interval);
+        i = offset - (latestBlock["timestamp"] % interval);
       }
 
       await yam.testing.increaseTime(i);
@@ -1063,7 +1063,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -1071,10 +1071,10 @@ describe("rebase_tests", () => {
       interval = yam.toBigN(interval).toNumber();
 
       let i;
-      if (a["timestamp"] % interval > offset) {
-        i = (interval - (a["timestamp"] % interval)) + offset;
+      if (latestBlock["timestamp"] % interval > offset) {
+        i = (interval - (latestBlock["timestamp"] % interval)) + offset;
       } else {
-        i = offset - (a["timestamp"] % interval);
+        i = offset - (latestBlock["timestamp"] % interval);
       }
 
       let len = await yam.contracts.rebaser.methods.rebaseWindowLengthSec().call();
@@ -1205,7 +1205,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let a = await yam.web3.eth.getBlock('latest');
+      let latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -1213,15 +1213,13 @@ describe("rebase_tests", () => {
       interval = yam.toBigN(interval).toNumber();
 
       let i;
-      if (a["timestamp"] % interval > offset) {
-        i = (interval - (a["timestamp"] % interval)) + offset;
+      if (latestBlock["timestamp"] % interval > offset) {
+        i = (interval - (latestBlock["timestamp"] % interval)) + offset;
       } else {
-        i = offset - (a["timestamp"] % interval);
+        i = offset - (latestBlock["timestamp"] % interval);
       }
 
       await yam.testing.increaseTime(i - 1);
-
-
 
       let b = await yam.testing.expectThrow(yam.contracts.rebaser.methods.rebase().send({
         from: user,

--- a/yam-www/src/yam/tests/rebase.test.js
+++ b/yam-www/src/yam/tests/rebase.test.js
@@ -33,7 +33,7 @@ describe("rebase_tests", () => {
   let user;
   let new_user;
   // let unlocked_account = "0x0eb4add4ba497357546da7f5d12d39587ca24606";
-  let unlocked_account = "0x681148725731f213b0187a3cbef215c291d85a3e";
+  const unlocked_account = "0x681148725731f213b0187a3cbef215c291d85a3e";
 
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
@@ -44,14 +44,14 @@ describe("rebase_tests", () => {
 
   beforeEach(async () => {
     await yam.testing.resetEVM("0x2");
-    let latestBlock = await yam.contracts.ycrv.methods.transfer(user, "2000000000000000000000000").send({
+    const latestBlock = await yam.contracts.ycrv.methods.transfer(user, "2000000000000000000000000").send({
       from: unlocked_account
     });
   });
 
   describe("rebase", () => {
     test("user has ycrv", async () => {
-      let bal0 = await yam.contracts.ycrv.methods.balanceOf(user).call();
+      const bal0 = await yam.contracts.ycrv.methods.balanceOf(user).call();
       expect(bal0).toBe("2000000000000000000000000");
     });
     test("create pair", async () => {
@@ -92,12 +92,12 @@ describe("rebase_tests", () => {
         from: user,
         gas: 8000000
       });
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
       yam.contracts.uni_pair.options.address = pair;
-      let bal = await yam.contracts.uni_pair.methods.balanceOf(user).call();
+      const bal = await yam.contracts.uni_pair.methods.balanceOf(user).call();
       expect(yam.toBigN(bal).toNumber()).toBeGreaterThan(100)
     });
     test("init_twap", async () => {
@@ -129,12 +129,12 @@ describe("rebase_tests", () => {
         from: user,
         gas: 8000000
       });
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
       yam.contracts.uni_pair.options.address = pair;
-      let bal = await yam.contracts.uni_pair.methods.balanceOf(user).call();
+      const bal = await yam.contracts.uni_pair.methods.balanceOf(user).call();
 
       // make a trade to get init values in uniswap
       await yam.contracts.uni_router.methods.swapExactTokensForTokens(
@@ -160,8 +160,8 @@ describe("rebase_tests", () => {
 
 
 
-      let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
-      let priceCumulativeLast = await yam.contracts.rebaser.methods.priceCumulativeLast().call();
+      const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+      const priceCumulativeLast = await yam.contracts.rebaser.methods.priceCumulativeLast().call();
       expect(yam.toBigN(init_twap).toNumber()).toBeGreaterThan(0);
       expect(yam.toBigN(priceCumulativeLast).toNumber()).toBeGreaterThan(0);
     });
@@ -194,12 +194,12 @@ describe("rebase_tests", () => {
         from: user,
         gas: 8000000
       });
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
       yam.contracts.uni_pair.options.address = pair;
-      let bal = await yam.contracts.uni_pair.methods.balanceOf(user).call();
+      const bal = await yam.contracts.uni_pair.methods.balanceOf(user).call();
 
       // make a trade to get init values in uniswap
       await yam.contracts.uni_router.methods.swapExactTokensForTokens(
@@ -225,8 +225,8 @@ describe("rebase_tests", () => {
 
 
 
-      let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
-      let priceCumulativeLast = await yam.contracts.rebaser.methods.priceCumulativeLast().call();
+      const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+      const priceCumulativeLast = await yam.contracts.rebaser.methods.priceCumulativeLast().call();
       expect(yam.toBigN(init_twap).toNumber()).toBeGreaterThan(0);
       expect(yam.toBigN(priceCumulativeLast).toNumber()).toBeGreaterThan(0);
 
@@ -267,7 +267,7 @@ describe("rebase_tests", () => {
         gas: 8000000
       });
 
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
@@ -328,7 +328,7 @@ describe("rebase_tests", () => {
       });
 
       // init twap
-      let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+      const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
 
       // wait 12 hours
       await yam.testing.increaseTime(12 * 60 * 60);
@@ -355,7 +355,7 @@ describe("rebase_tests", () => {
       });
 
 
-      let res_bal = await yam.contracts.yam.methods.balanceOf(
+      const res_bal = await yam.contracts.yam.methods.balanceOf(
           yam.contracts.reserves.options.address
       ).call();
 
@@ -363,7 +363,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let latestBlock = await yam.web3.eth.getBlock('latest');
+      const latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -383,7 +383,7 @@ describe("rebase_tests", () => {
       let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
       console.log("quote pre positive rebase", q);
 
-      let b = await yam.contracts.rebaser.methods.rebase().send({
+      const b = await yam.contracts.rebaser.methods.rebase().send({
         from: user,
         gas: 2500000
       });
@@ -391,11 +391,11 @@ describe("rebase_tests", () => {
       //console.log(b.events)
       console.log("positive rebase gas used:", b["gasUsed"]);
 
-      let bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
+      const bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
+      const resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
-      let resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
+      const resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
       console.log("bal user, bal yam res, bal res crv", bal1, resYAM, resycrv);
       [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
@@ -443,7 +443,7 @@ describe("rebase_tests", () => {
         gas: 8000000
       });
 
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
@@ -504,7 +504,7 @@ describe("rebase_tests", () => {
       });
 
       // init twap
-      let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+      const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
 
       // wait 12 hours
       await yam.testing.increaseTime(12 * 60 * 60);
@@ -533,7 +533,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let latestBlock = await yam.web3.eth.getBlock('latest');
+      const latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -549,11 +549,11 @@ describe("rebase_tests", () => {
 
       await yam.testing.increaseTime(i);
 
-      let [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
-      let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
+      const [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+      const q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
       console.log("quote pre negative rebase", q);
 
-      let b = await yam.contracts.rebaser.methods.rebase().send({
+      const b = await yam.contracts.rebaser.methods.rebase().send({
         from: user,
         gas: 2500000
       });
@@ -561,11 +561,11 @@ describe("rebase_tests", () => {
       //console.log(b.events)
       console.log("negative rebase gas used:", b["gasUsed"]);
 
-      let bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
+      const bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
+      const resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
-      let resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
+      const resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
       // balance decreases
       expect(yam.toBigN(bal1).toNumber()).toBeLessThan(yam.toBigN(bal).toNumber());
@@ -603,7 +603,7 @@ describe("rebase_tests", () => {
         gas: 8000000
       });
 
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
@@ -678,7 +678,7 @@ describe("rebase_tests", () => {
       });
 
       // init twap
-      let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+      const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
 
       // wait 12 hours
       await yam.testing.increaseTime(12 * 60 * 60);
@@ -721,7 +721,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let latestBlock = await yam.web3.eth.getBlock('latest');
+      const latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -741,18 +741,18 @@ describe("rebase_tests", () => {
       console.log([reserveA, reserveB]);
       let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
       console.log("quote pre no rebase", q);
-      let b = await yam.contracts.rebaser.methods.rebase().send({
+      const b = await yam.contracts.rebaser.methods.rebase().send({
         from: user,
         gas: 2500000
       });
 
       console.log("no rebase gas used:", b["gasUsed"]);
 
-      let bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
+      const bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
+      const resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
-      let resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
+      const resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
       // no change
       expect(yam.toBigN(bal1).toNumber()).toBe(yam.toBigN(bal).toNumber());
@@ -794,7 +794,7 @@ describe("rebase_tests", () => {
         gas: 8000000
       });
 
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
@@ -855,7 +855,7 @@ describe("rebase_tests", () => {
       });
 
       // init twap
-      let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+      const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
 
       // wait 12 hours
       await yam.testing.increaseTime(12 * 60 * 60);
@@ -884,7 +884,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let latestBlock = await yam.web3.eth.getBlock('latest');
+      const latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -905,7 +905,7 @@ describe("rebase_tests", () => {
       let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
       console.log("quote pre pos rebase with reserves", q);
 
-      let b = await yam.contracts.rebaser.methods.rebase().send({
+      const b = await yam.contracts.rebaser.methods.rebase().send({
         from: user,
         gas: 2500000
       });
@@ -913,11 +913,11 @@ describe("rebase_tests", () => {
 
       console.log("positive  with reserves gas used:", b["gasUsed"]);
 
-      let bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
+      const bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
+      const resYAM = await yam.contracts.yam.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
-      let resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
+      const resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
       console.log(bal, bal1, resYAM, resycrv);
       expect(yam.toBigN(bal).toNumber()).toBeLessThan(yam.toBigN(bal1).toNumber());
@@ -973,7 +973,7 @@ describe("rebase_tests", () => {
         gas: 8000000
       });
 
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
@@ -1034,7 +1034,7 @@ describe("rebase_tests", () => {
       });
 
       // init twap
-      let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+      const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
 
       // wait 12 hours
       await yam.testing.increaseTime(12 * 60 * 60);
@@ -1063,7 +1063,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let latestBlock = await yam.web3.eth.getBlock('latest');
+      const latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -1077,11 +1077,11 @@ describe("rebase_tests", () => {
         i = offset - (latestBlock["timestamp"] % interval);
       }
 
-      let len = await yam.contracts.rebaser.methods.rebaseWindowLengthSec().call();
+      const len = await yam.contracts.rebaser.methods.rebaseWindowLengthSec().call();
 
       await yam.testing.increaseTime(i + yam.toBigN(len).toNumber()+1);
 
-      let b = await yam.testing.expectThrow(yam.contracts.rebaser.methods.rebase().send({
+      const b = await yam.testing.expectThrow(yam.contracts.rebaser.methods.rebase().send({
         from: user,
         gas: 2500000
       }), "too late");
@@ -1116,7 +1116,7 @@ describe("rebase_tests", () => {
         gas: 8000000
       });
 
-      let pair = await yam.contracts.uni_fact.methods.getPair(
+      const pair = await yam.contracts.uni_fact.methods.getPair(
         yam.contracts.yam.options.address,
         yam.contracts.ycrv.options.address
       ).call();
@@ -1177,7 +1177,7 @@ describe("rebase_tests", () => {
       });
 
       // init twap
-      let init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
+      const init_twap = await yam.contracts.rebaser.methods.timeOfTWAPInit().call();
 
       // wait 12 hours
       await yam.testing.increaseTime(12 * 60 * 60);
@@ -1205,7 +1205,7 @@ describe("rebase_tests", () => {
 
       bal = await yam.contracts.yam.methods.balanceOf(user).call();
 
-      let latestBlock = await yam.web3.eth.getBlock('latest');
+      const latestBlock = await yam.web3.eth.getBlock('latest');
 
       let offset = await yam.contracts.rebaser.methods.rebaseWindowOffsetSec().call();
       offset = yam.toBigN(offset).toNumber();
@@ -1221,7 +1221,7 @@ describe("rebase_tests", () => {
 
       await yam.testing.increaseTime(i - 1);
 
-      let b = await yam.testing.expectThrow(yam.contracts.rebaser.methods.rebase().send({
+      const b = await yam.testing.expectThrow(yam.contracts.rebaser.methods.rebase().send({
         from: user,
         gas: 2500000
       }), "too early");

--- a/yam-www/src/yam/tests/rebase.test.js
+++ b/yam-www/src/yam/tests/rebase.test.js
@@ -379,8 +379,8 @@ describe("rebase_tests", () => {
 
       await yam.testing.increaseTime(i);
 
-      let r = await yam.contracts.uni_pair.methods.getReserves().call();
-      let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+      let [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+      let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
       console.log("quote pre positive rebase", q);
 
       let b = await yam.contracts.rebaser.methods.rebase().send({
@@ -398,8 +398,8 @@ describe("rebase_tests", () => {
       let resycrv = await yam.contracts.ycrv.methods.balanceOf(yam.contracts.reserves.options.address).call();
 
       console.log("bal user, bal yam res, bal res crv", bal1, resYAM, resycrv);
-      r = await yam.contracts.uni_pair.methods.getReserves().call();
-      q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+      [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+      q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
       console.log("post positive rebase quote", q);
 
       // new balance > old balance
@@ -549,8 +549,8 @@ describe("rebase_tests", () => {
 
       await yam.testing.increaseTime(i);
 
-      let r = await yam.contracts.uni_pair.methods.getReserves().call();
-      let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+      let [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+      let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
       console.log("quote pre negative rebase", q);
 
       let b = await yam.contracts.rebaser.methods.rebase().send({
@@ -737,9 +737,9 @@ describe("rebase_tests", () => {
 
       await yam.testing.increaseTime(i);
 
-      let r = await yam.contracts.uni_pair.methods.getReserves().call();
-      console.log(r, r[0], r[1]);
-      let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+      let [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+      console.log([reserveA, reserveB]);
+      let q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
       console.log("quote pre no rebase", q);
       let b = await yam.contracts.rebaser.methods.rebase().send({
         from: user,
@@ -759,8 +759,8 @@ describe("rebase_tests", () => {
       // no increases to reserves
       expect(yam.toBigN(resYAM).toNumber()).toBe(0);
       expect(yam.toBigN(resycrv).toNumber()).toBe(0);
-      r = await yam.contracts.uni_pair.methods.getReserves().call();
-      q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), r[0], r[1]).call();
+      [reserveA, reserveB] = await yam.contracts.uni_pair.methods.getReserves().call();
+      q = await yam.contracts.uni_router.methods.quote(yam.toBigN(10**18).toString(), reserveA, reserveB).call();
       console.log("quote post no rebase", q);
     });
     test("rebasing with YAM in reserves", async () => {

--- a/yam-www/src/yam/tests/rebase.test.js
+++ b/yam-www/src/yam/tests/rebase.test.js
@@ -37,9 +37,8 @@ describe("rebase_tests", () => {
 
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
-    yam.addAccount(accounts[0]);
-    user = accounts[0];
-    new_user = accounts[1];
+    [user, new_user] = accounts;
+    yam.addAccount(user);
     snapshotId = await yam.testing.snapshot();
   });
 

--- a/yam-www/src/yam/tests/token.test.js
+++ b/yam-www/src/yam/tests/token.test.js
@@ -55,42 +55,43 @@ describe("token_tests", () => {
 
   describe("non-failing transfers", () => {
     test("transfer to self doesnt inflate", async () => {
-      let bal0 = await yam.contracts.yam.methods.balanceOf(user).call();
+      const bal0 = await yam.contracts.yam.methods.balanceOf(user).call();
       await yam.contracts.yam.methods.transfer(user, "100").send({from: user});
-      let bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
+      const bal1 = await yam.contracts.yam.methods.balanceOf(user).call();
       expect(bal0).toBe(bal1);
     });
     test("transferFrom works", async () => {
-      let bal00 = await yam.contracts.yam.methods.balanceOf(user).call();
-      let bal01 = await yam.contracts.yam.methods.balanceOf(new_user).call();
+      const bal00 = await yam.contracts.yam.methods.balanceOf(user).call();
+      const bal01 = await yam.contracts.yam.methods.balanceOf(new_user).call();
       await yam.contracts.yam.methods.approve(new_user, "100").send({from: user});
       await yam.contracts.yam.methods.transferFrom(user, new_user, "100").send({from: new_user});
-      let bal10 = await yam.contracts.yam.methods.balanceOf(user).call();
-      let bal11 = await yam.contracts.yam.methods.balanceOf(new_user).call();
+      const bal10 = await yam.contracts.yam.methods.balanceOf(user).call();
+      const bal11 = await yam.contracts.yam.methods.balanceOf(new_user).call();
       expect((yam.toBigN(bal01).plus(yam.toBigN(100))).toString()).toBe(bal11);
       expect((yam.toBigN(bal00).minus(yam.toBigN(100))).toString()).toBe(bal10);
     });
     test("approve", async () => {
       await yam.contracts.yam.methods.approve(new_user, "100").send({from: user});
-      let allowance = await yam.contracts.yam.methods.allowance(user, new_user).call();
+      const allowance = await yam.contracts.yam.methods.allowance(user, new_user).call();
       expect(allowance).toBe("100")
     });
     test("increaseAllowance", async () => {
       await yam.contracts.yam.methods.increaseAllowance(new_user, "100").send({from: user});
-      let allowance = await yam.contracts.yam.methods.allowance(user, new_user).call();
+      const allowance = await yam.contracts.yam.methods.allowance(user, new_user).call();
       expect(allowance).toBe("100")
     });
     test("decreaseAllowance", async () => {
       await yam.contracts.yam.methods.increaseAllowance(new_user, "100").send({from: user});
       let allowance = await yam.contracts.yam.methods.allowance(user, new_user).call();
       expect(allowance).toBe("100")
+
       await yam.contracts.yam.methods.decreaseAllowance(new_user, "100").send({from: user});
       allowance = await yam.contracts.yam.methods.allowance(user, new_user).call();
       expect(allowance).toBe("0")
     });
     test("decreaseAllowance from 0", async () => {
       await yam.contracts.yam.methods.decreaseAllowance(new_user, "100").send({from: user});
-      let allowance = await yam.contracts.yam.methods.allowance(user, new_user).call();
+      const allowance = await yam.contracts.yam.methods.allowance(user, new_user).call();
       expect(allowance).toBe("0")
     });
   })

--- a/yam-www/src/yam/tests/token.test.js
+++ b/yam-www/src/yam/tests/token.test.js
@@ -34,9 +34,8 @@ describe("token_tests", () => {
   let new_user;
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
-    yam.addAccount(accounts[0]);
-    user = accounts[0];
-    new_user = accounts[1];
+    [user, new_user] = accounts;
+    yam.addAccount(user);
     snapshotId = await yam.testing.snapshot();
   });
 

--- a/yam-www/src/yam/tests/token2.test.js
+++ b/yam-www/src/yam/tests/token2.test.js
@@ -31,7 +31,7 @@ const oneEther = 10 ** 18;
 describe("token_tests", () => {
   let snapshotId;
   let new_user;
-  let user = "0x683A78bA1f6b25E29fbBC9Cd1BFA29A51520De84";
+  const user = "0x683A78bA1f6b25E29fbBC9Cd1BFA29A51520De84";
   beforeAll(async () => {
     const accounts = await yam.web3.eth.getAccounts();
     yam.addAccount(accounts[0]);
@@ -66,38 +66,38 @@ describe("token_tests", () => {
 
   describe("non-failing", () => {
     test("name", async () => {
-      let name = await yam.contracts.yamV2.methods.name().call();
+      const name = await yam.contracts.yamV2.methods.name().call();
       expect(name).toBe("YAMv2");
     });
     test("symbol", async () => {
-      let symbol = await yam.contracts.yamV2.methods.symbol().call();
+      const symbol = await yam.contracts.yamV2.methods.symbol().call();
       expect(symbol).toBe("YAMv2");
     });
     test("decimals", async () => {
-      let decimals = await yam.contracts.yamV2.methods.decimals().call();
+      const decimals = await yam.contracts.yamV2.methods.decimals().call();
       expect(decimals).toBe("24");
     });
     test("totalSupply", async () => {
-      let ts = await yam.contracts.yamV2.methods.totalSupply().call();
+      const ts = await yam.contracts.yamV2.methods.totalSupply().call();
       expect(ts).toBe("0");
     });
     test("transfer to self doesnt inflate", async () => {
       await yam.contracts.yam.methods.approve(yam.contracts.yamV2migration.options.address, "10000000000000000000000000000000000").send({from: user, gas: 1000000});
       await yam.contracts.yamV2migration.methods.migrate().send({from: user});
-      let bal0 = await yam.contracts.yamV2.methods.balanceOf(user).call();
+      const bal0 = await yam.contracts.yamV2.methods.balanceOf(user).call();
       await yam.contracts.yamV2.methods.transfer(user, "100").send({from: user});
-      let bal1 = await yam.contracts.yamV2.methods.balanceOf(user).call();
+      const bal1 = await yam.contracts.yamV2.methods.balanceOf(user).call();
       expect(bal0).toBe(bal1);
     });
     test("transferFrom works", async () => {
       await yam.contracts.yam.methods.approve(yam.contracts.yamV2migration.options.address, "10000000000000000000000000000000000").send({from: user, gas: 1000000});
       await yam.contracts.yamV2migration.methods.migrate().send({from: user});
-      let bal00 = await yam.contracts.yamV2.methods.balanceOf(user).call();
-      let bal01 = await yam.contracts.yamV2.methods.balanceOf(new_user).call();
+      const bal00 = await yam.contracts.yamV2.methods.balanceOf(user).call();
+      const bal01 = await yam.contracts.yamV2.methods.balanceOf(new_user).call();
       await yam.contracts.yamV2.methods.approve(new_user, "100").send({from: user});
       await yam.contracts.yamV2.methods.transferFrom(user, new_user, "100").send({from: new_user});
-      let bal10 = await yam.contracts.yamV2.methods.balanceOf(user).call();
-      let bal11 = await yam.contracts.yamV2.methods.balanceOf(new_user).call();
+      const bal10 = await yam.contracts.yamV2.methods.balanceOf(user).call();
+      const bal11 = await yam.contracts.yamV2.methods.balanceOf(new_user).call();
       expect((yam.toBigN(bal01).plus(yam.toBigN(100))).toString()).toBe(bal11);
       expect((yam.toBigN(bal00).minus(yam.toBigN(100))).toString()).toBe(bal10);
     });
@@ -105,23 +105,28 @@ describe("token_tests", () => {
       await yam.contracts.yam.methods.approve(yam.contracts.yamV2migration.options.address, "10000000000000000000000000000000000").send({from: user, gas: 1000000});
       await yam.contracts.yamV2migration.methods.migrate().send({from: user});
       await yam.contracts.yamV2.methods.approve(new_user, "100").send({from: user});
-      let allowance = await yam.contracts.yamV2.methods.allowance(user, new_user).call();
+
+      const allowance = await yam.contracts.yamV2.methods.allowance(user, new_user).call();
       expect(allowance).toBe("100")
     });
     test("increaseAllowance", async () => {
       await yam.contracts.yam.methods.approve(yam.contracts.yamV2migration.options.address, "10000000000000000000000000000000000").send({from: user, gas: 1000000});
       await yam.contracts.yamV2migration.methods.migrate().send({from: user});
       await yam.contracts.yamV2.methods.increaseAllowance(new_user, "100").send({from: user});
-      let allowance = await yam.contracts.yamV2.methods.allowance(user, new_user).call();
+
+      const allowance = await yam.contracts.yamV2.methods.allowance(user, new_user).call();
       expect(allowance).toBe("100")
     });
     test("decreaseAllowance", async () => {
       await yam.contracts.yam.methods.approve(yam.contracts.yamV2migration.options.address, "10000000000000000000000000000000000").send({from: user, gas: 1000000});
       await yam.contracts.yamV2migration.methods.migrate().send({from: user});
       await yam.contracts.yamV2.methods.increaseAllowance(new_user, "100").send({from: user});
+
       let allowance = await yam.contracts.yamV2.methods.allowance(user, new_user).call();
       expect(allowance).toBe("100")
+
       await yam.contracts.yamV2.methods.decreaseAllowance(new_user, "100").send({from: user});
+
       allowance = await yam.contracts.yamV2.methods.allowance(user, new_user).call();
       expect(allowance).toBe("0")
     });


### PR DESCRIPTION
1. Prefer array destructuring assignment for initializing values
2. Use clear names for some variables; `latestBlock`, `reserveA`, `reserveB` -Which was previously `a`, `r1`, `r2` each
3. Switch to `const` for `let` variables which was never reassigned